### PR TITLE
run php artisan route:cache,route bindings  wrong

### DIFF
--- a/RouteGroup.php
+++ b/RouteGroup.php
@@ -59,7 +59,7 @@ class RouteGroup
     {
         $old = $old['prefix'] ?? null;
 
-        return isset($new['prefix']) ? trim($old, '/').'/'.trim($new['prefix'], '/') : $old;
+        return isset($new['prefix']) ? trim($new['prefix'], '/').'/'.trim($old, '/') : $old;
     }
 
     /**


### PR DESCRIPTION
When I use the route cache, I will get an error with the route binding parameters, so I trace the source code, and modify it here is no problem
![image](https://user-images.githubusercontent.com/20275621/77681675-a926e280-6fd0-11ea-89e9-49f59fd7680d.png)
